### PR TITLE
Fix Issue #8 - add 367 (RPL_ENDOFMOTD) to REGISTRATION_COMMANDS

### DIFF
--- a/lib/cinch/irc.rb
+++ b/lib/cinch/irc.rb
@@ -13,7 +13,7 @@ module Cinch
     include Helpers
 
     # @api private
-    REGISTRATION_COMMANDS = %w[001 002 003 004 422].freeze
+    REGISTRATION_COMMANDS = %w[001 002 003 004 376 422].freeze
     # @api private
     PRIVMSG_NOTICE_COMMANDS = %w[PRIVMSG NOTICE].freeze
 
@@ -284,7 +284,7 @@ module Cinch
 
     # @return [Boolean] true if we successfully registered yet
     def registered?
-      (("001".."004").to_a - @registration).empty? || @registration.include?("422")
+      (("001".."004").to_a - @registration).empty? || @registration.include?("376") || @registration.include?("422")
     end
 
     # Send a message to the server.

--- a/test/lib/cinch/irc.rb
+++ b/test/lib/cinch/irc.rb
@@ -113,6 +113,24 @@ class IRCTest < TestCase
     assert_includes @bot.handlers.dispatched, :connect
   end
 
+  test "parse handles numeric 376 as registration" do
+    @irc.setup
+
+    @irc.parse(":server 376 bot :End of /MOTD command.")
+    assert @irc.registered?, "Should be registered after 376"
+
+    assert_includes @bot.handlers.dispatched, :connect
+  end
+
+  test "parse handles numeric 422 as registration" do
+    @irc.setup
+
+    @irc.parse(":server 376 bot :No /MOTD set up.")
+    assert @irc.registered?, "Should be registered after 422"
+
+    assert_includes @bot.handlers.dispatched, :connect
+  end
+
   test "send_login sends auth commands" do
     @bot.config.password = "secret"
     @bot.config.nick = "bot"


### PR DESCRIPTION
We currently check for either 001..004 OR a lack of MOTD, but we should also check for ENDOFMOTD.